### PR TITLE
fix NotImplementedError. Followed diffusers CrossAttention

### DIFF
--- a/paint_with_words/paint_with_words.py
+++ b/paint_with_words/paint_with_words.py
@@ -79,8 +79,13 @@ def inj_forward(self, hidden_states, context=None, mask=None):
     hidden_states = torch.matmul(attention_probs, value)
 
     hidden_states = self.reshape_batch_dim_to_heads(hidden_states)
+    
+    #linear proj
+    hidden_states = self.to_out[0](hidden_states)
+    #dropout
+    hidden_states = self.to_out[1](hidden_states)
 
-    return self.to_out(hidden_states)
+    return hidden_states
 
 
 def _load_tools(device: str, scheduler_type):


### PR DESCRIPTION
Hi thanks for the great implementation of paint with words.

self.to_out is a Module_List which does not have forward function (as far as i know). 

I followed the original implementation CrossAttention in diffusers and it works great.